### PR TITLE
Updates (polling and empty list)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mechanicabot",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Mechanica Telegram Bot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
This PR will:
1. Switch the user list updates to polling with a 60 second interval.
2. Remove the need for a persistent connection to the Unifi AP.
3. Add an explicit note for an empty user list.